### PR TITLE
Add metadata into the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Additionally, it ***must*** have a `#description` method that returns a string.
 
 Additionally it ***should*** implement `#manifest_url` that shows where the manifest can be found. 
 
+Additionally it ***should*** implement `#manifest_metadata` to provide an array containing hashes of metadata Label/Value pairs. 
+
 Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`). 
 
 Finally, It ***may*** implement `ranges`, which returns an array of objects which
 represent a table of contents or similar structure, each of which responds to
 `label`, `ranges`, and `file_set_presenters`.
-
 
 For example:
 
@@ -42,8 +43,15 @@ For example:
     def description
       'a brief description'
     end
+    
+    def manifest_metadata
+          [
+            { "label" => "Title", "value" => "Title of the Item" },
+            { "label" => "Creator", "value" => "Morrissey, Stephen Patrick" }
+          ]
+    end
 
-    def sequence_rendering:
+    def sequence_rendering
       [{"@id" => "http://test.host/file_set/id/download", "format" => "application/pdf", "label" => "Download"}]
     end
 

--- a/iiif_manifest.gemspec
+++ b/iiif_manifest.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'iiif_manifest/version'

--- a/lib/iiif_manifest/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/record_property_builder.rb
@@ -11,6 +11,7 @@ module IIIFManifest
         manifest.label = record.to_s
         manifest.description = record.description
         manifest.viewing_hint = viewing_hint if viewing_hint.present?
+        manifest.metadata = record.manifest_metadata if valid_metadata?
         manifest
       end
 
@@ -18,6 +19,31 @@ module IIIFManifest
 
       def viewing_hint
         (record.respond_to?(:viewing_hint) && record.send(:viewing_hint))
+      end
+
+      # Validate manifest_metadata against the IIIF spec format for metadata
+      #
+      # @return [Boolean]
+      def valid_metadata?
+        return false unless record.respond_to?(:manifest_metadata)
+        metadata = record.manifest_metadata
+        valid_metadata_structure?(metadata) && valid_metadata_content?(metadata)
+      end
+
+      # Manifest metadata must be an array containing hashes
+      #
+      # @param metadata [Array<Hash>] a list of metadata with label and value as required keys for each entry
+      # @return [Boolean]
+      def valid_metadata_structure?(metadata)
+        metadata.is_a?(Array) && metadata.all? { |v| v.is_a?(Hash) }
+      end
+
+      # Manifest Metadata Hashes must contain 'label' and 'value' keys
+      #
+      # @param metadata [Array<Hash>] a list of metadata with label and value as required keys for each entry
+      # @return [Boolean]
+      def valid_metadata_content?(metadata)
+        metadata.all? { |v| v['label'].present? && v['value'].present? }
       end
     end
   end

--- a/lib/iiif_manifest/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/structure_builder.rb
@@ -9,7 +9,7 @@ module IIIFManifest
       end
 
       def apply(manifest)
-        top_ranges.each_with_index do |top_range|
+        top_ranges.each do |top_range|
           manifest['structures'] ||= []
           manifest['structures'] = range_builder(top_range).apply(manifest['structures'])
         end

--- a/spec/lib/iiif_manifest/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_factory_spec.rb
@@ -163,6 +163,35 @@ RSpec.describe IIIFManifest::ManifestFactory do
       end
     end
 
+    context 'where there is a no manifest_metadata method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a metadata element' do
+        allow(IIIFManifest::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['metadata']).to eq nil
+      end
+    end
+
+    context 'where there is a manifest_metadata method' do
+      let(:metadata) { [{ 'label' => 'Title', 'value' => 'Title of the Item' }] }
+
+      it 'has metadata' do
+        allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
+        expect(result['metadata'][0]['label']).to eq 'Title'
+        expect(result['metadata'][0]['value']).to eq 'Title of the Item'
+      end
+    end
+
+    context 'where there is a manifest_metadata method with invalid data' do
+      let(:metadata) { 'invalid data' }
+
+      it 'has no metadata' do
+        allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
+        expect(result['metadata']).to eq nil
+      end
+    end
+
     context 'when there are child works' do
       let(:child_work_presenter) { presenter_class.new('test2') }
 


### PR DESCRIPTION
I've added an optional `manifest_metadata` method to enable the addition of metadata as per the IIIF Presentation API.

I have added some lightweight validation of the metadata received to ensure it's a) an Array of Hashes, and b) the Hashes contain 'label and 'value' keys.

Pulled in changes from #10 to make the build pass.