### PR TITLE
add search_service for exposing search endpoint in IIIF presentation manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Additionally it ***should*** implement `#manifest_url` that shows where the mani
 
 Additionally it ***should*** implement `#manifest_metadata` to provide an array containing hashes of metadata Label/Value pairs. 
 
-Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`). 
+Additionally it ***may*** implement `#search_service` to contain the url for an IIIF search api compliant search endpoint.
+
+Additionally it ***may*** implement `#search_service_version` to contain the version of the IIIF search api. Valid values are `0` or `1`. If not supplied, the default is `0`. Universal Viewer 2 and 3 support only version 0.
+ 
+Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`).
 
 Finally, It ***may*** implement `ranges`, which returns an array of objects which
 represent a table of contents or similar structure, each of which responds to
@@ -49,6 +53,14 @@ For example:
             { "label" => "Title", "value" => "Title of the Item" },
             { "label" => "Creator", "value" => "Morrissey, Stephen Patrick" }
           ]
+    end
+    
+    def search_service
+      "http://test.host/books/#{@id}/search"
+    end
+    
+    def search_service_version
+      1
     end
 
     def sequence_rendering

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -12,4 +12,5 @@ module IIIFManifest
   autoload :DisplayImage
   autoload :IIIFCollection
   autoload :IIIFEndpoint
+  autoload :IIIFSearchEndpoint
 end

--- a/lib/iiif_manifest/iiif_search_endpoint.rb
+++ b/lib/iiif_manifest/iiif_search_endpoint.rb
@@ -1,0 +1,24 @@
+module IIIFManifest
+  # IIIF Search Endpoint for http://iiif.io/api/search/1.0
+  # Intended to be used to populate a service description it an IIIF Presentation Manifest
+  #   see http://iiif.io/api/search/1.0/#service-description
+  # Univeral Viewer supports version 0 only (the search box will not show otherwise):
+  #   see http://ronallo.com/iiif-workshop/search/service-in-manifest.html
+  #   see https://github.com/UniversalViewer/universalviewer/blob/master/src/lib/manifesto.js
+  class IIIFSearchEndpoint
+    attr_reader :url, :label, :version
+    def initialize(url, label: 'Search within this manifest', version: '0')
+      @url = url
+      @label = label
+      @version = version
+    end
+
+    def profile
+      "http://iiif.io/api/search/#{version}/search"
+    end
+
+    def context
+      "http://iiif.io/api/search/#{version}/context.json"
+    end
+  end
+end

--- a/lib/iiif_manifest/manifest_builder.rb
+++ b/lib/iiif_manifest/manifest_builder.rb
@@ -8,6 +8,7 @@ require_relative 'manifest_builder/image_builder'
 require_relative 'manifest_builder/image_service_builder'
 require_relative 'manifest_builder/record_property_builder'
 require_relative 'manifest_builder/resource_builder'
+require_relative 'manifest_builder/search_service_builder'
 require_relative 'manifest_builder/sequence_builder'
 require_relative 'manifest_builder/structure_builder'
 

--- a/lib/iiif_manifest/manifest_builder/search_service_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/search_service_builder.rb
@@ -1,0 +1,32 @@
+module IIIFManifest
+  class ManifestBuilder
+    # IIIF Search Service Builder
+    # Creates a service description for use in an IIIF Presenation Manifest
+    #   see http://iiif.io/api/search/1.0/#service-description
+    class SearchServiceBuilder
+      attr_reader :iiif_search_endpoint, :iiif_service_factory
+      def initialize(iiif_search_endpoint, iiif_service_factory:)
+        @iiif_search_endpoint = iiif_search_endpoint
+        @iiif_service_factory = iiif_service_factory
+      end
+
+      def apply(resource)
+        apply_to_service
+        resource.service << service
+      end
+
+      def apply_to_service
+        service['@context'] = iiif_search_endpoint.context
+        service['@id'] = iiif_search_endpoint.url
+        service['profile'] = iiif_search_endpoint.profile
+        service['label'] = iiif_search_endpoint.label
+      end
+
+      private
+
+      def service
+        @service ||= iiif_service_factory.new
+      end
+    end
+  end
+end

--- a/lib/iiif_manifest/manifest_service_locator.rb
+++ b/lib/iiif_manifest/manifest_service_locator.rb
@@ -80,7 +80,17 @@ module IIIFManifest
       end
 
       def record_property_builder
-        ManifestBuilder::RecordPropertyBuilder
+        InjectedFactory.new(
+          ManifestBuilder::RecordPropertyBuilder,
+          search_service_builder_factory: search_service_builder_factory
+        )
+      end
+
+      def search_service_builder_factory
+        InjectedFactory.new(
+          ManifestBuilder::SearchServiceBuilder,
+          iiif_service_factory: iiif_service_factory
+        )
       end
 
       def structure_builder

--- a/spec/lib/iiif_manifest/iiif_search_endpoint_spec.rb
+++ b/spec/lib/iiif_manifest/iiif_search_endpoint_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::IIIFSearchEndpoint do
+  let(:endpoint) { described_class.new(url) }
+
+  let(:url) { 'http://bla.org' }
+
+  context 'with default values' do
+    it 'has accessors' do
+      expect(endpoint.url).to eq url
+      expect(endpoint.label).to eq 'Search within this manifest'
+    end
+    it 'can return context' do
+      expect(endpoint.context).to eq 'http://iiif.io/api/search/0/context.json'
+    end
+    it 'can return profile' do
+      expect(endpoint.profile).to eq 'http://iiif.io/api/search/0/search'
+    end
+  end
+
+  context 'with user supplied valued' do
+    let(:endpoint) { described_class.new(url, label: 'Search this manifest', version: '1') }
+
+    let(:url) { 'http://bla.org' }
+
+    it 'has accessors' do
+      expect(endpoint.url).to eq url
+      expect(endpoint.label).to eq 'Search this manifest'
+    end
+    it 'can return context' do
+      expect(endpoint.context).to eq 'http://iiif.io/api/search/1/context.json'
+    end
+    it 'can return profile' do
+      expect(endpoint.profile).to eq 'http://iiif.io/api/search/1/search'
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_factory_spec.rb
@@ -192,6 +192,46 @@ RSpec.describe IIIFManifest::ManifestFactory do
       end
     end
 
+    context 'when there is no search_service method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a service element' do
+        allow(IIIFManifest::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there is a search_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+
+      it 'has a service element' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service'][0]['@context']).to eq 'http://iiif.io/api/search/0/context.json'
+        expect(result['service'][0]['@id']).to eq 'http://test.host/books/book-77/search'
+      end
+    end
+
+    context 'when there is a search_service and search_service_version method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+      let(:search_service_version) { 1 }
+
+      it 'has a service element containing iiif.io/api/search version 1' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        allow(book_presenter).to receive(:search_service_version).and_return(search_service_version)
+        expect(result['service'][0]['@context']).to eq 'http://iiif.io/api/search/1/context.json'
+      end
+    end
+
+    context 'when there is a search_service method that returns nil' do
+      let(:search_service) { '' }
+
+      it 'has no service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service']).to eq nil
+      end
+    end
+
     context 'when there are child works' do
       let(:child_work_presenter) { presenter_class.new('test2') }
 


### PR DESCRIPTION
This PR adds an optional method `search_service` that, if present, adds a `service` block to the top level of the manifest to expose an IIIF search endpoint.

If the method is not present, the block is skipped.

If the method returns nil, or an empty string, the block is skipped. This means that an application with mixed content, some full-text searchable content and some not, could include the block only where the content is searchable.

By default, IIIF search api version 0 is supported, in line with what UV supports. This is configurable, by adding a `search_service_version` method.