### PR TITLE
Use hash-powered IIIF factories.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,9 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
 
+Naming/MethodName:
+  Exclude:
+    - 'lib/iiif_manifest/manifest_builder/iiif_service.rb'
+
 RSpec/MultipleExpectations:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,6 +65,7 @@ Style/Documentation:
     - 'lib/iiif_manifest/manifest_factory.rb'
     - 'lib/iiif_manifest/manifest_service_locator.rb'
     - 'lib/iiif_manifest.rb'
+    - 'lib/iiif_manifest/manifest_builder/iiif_service.rb'
     - 'spec/lib/iiif_manifest/manifest_factory_spec.rb'
 
 # Offense count: 1

--- a/iiif_manifest.gemspec
+++ b/iiif_manifest.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4'
-  spec.add_dependency 'iiif-presentation', '~> 0.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'pry-byebug'

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -2,7 +2,6 @@ require 'iiif_manifest/version'
 require 'active_support'
 require 'active_support/core_ext/module'
 require 'active_support/core_ext/object'
-require 'iiif/presentation' # AKA O'Sullivan
 
 module IIIFManifest
   extend ActiveSupport::Autoload

--- a/lib/iiif_manifest/manifest_builder.rb
+++ b/lib/iiif_manifest/manifest_builder.rb
@@ -1,3 +1,4 @@
+require_relative 'manifest_builder/iiif_service'
 require_relative 'manifest_builder/canvas_builder'
 require_relative 'manifest_builder/canvas_builder_factory'
 require_relative 'manifest_builder/child_manifest_builder_factory'

--- a/lib/iiif_manifest/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/manifest_builder/iiif_service.rb
@@ -1,0 +1,154 @@
+module IIIFManifest
+  class ManifestBuilder
+    class IIIFService
+      attr_reader :inner_hash
+      def initialize
+        @inner_hash = initial_attributes
+      end
+
+      delegate :[]=, :[], :as_json, :to_json, :has_key?, to: :inner_hash
+
+      def initial_attributes
+        {}
+      end
+    end
+
+    class IIIFManifest < IIIFService
+      def label
+        inner_hash['label']
+      end
+
+      def label=(label)
+        inner_hash['label'] = label
+      end
+
+      def description=(description)
+        return unless description.present?
+        inner_hash['description'] = description
+      end
+
+      def viewing_hint=(viewing_hint)
+        return unless viewing_hint.present?
+        inner_hash['viewingHint'] = viewing_hint
+      end
+
+      def viewing_direction=(viewing_direction)
+        return unless viewing_direction.present?
+        inner_hash['viewingDirection'] = viewing_direction
+      end
+
+      def viewingDirection
+        inner_hash['viewingDirection']
+      end
+
+      def sequences
+        inner_hash['sequences'] || []
+      end
+
+      def sequences=(sequences)
+        inner_hash['sequences'] = sequences
+      end
+
+      def metadata=(metadata)
+        inner_hash['metadata'] = metadata
+      end
+
+      def see_also=(see_also)
+        inner_hash['seeAlso'] = see_also
+      end
+
+      def license=(license)
+        inner_hash['license'] = license
+      end
+
+      def initial_attributes
+        {
+          '@context' => 'http://iiif.io/api/presentation/2/context.json',
+          '@type' => 'sc:Manifest'
+        }
+      end
+
+      class Collection < IIIFManifest
+        def initial_attributes
+          {
+            '@context' => 'http://iiif.io/api/presentation/2/context.json',
+            '@type' => 'sc:Collection'
+          }
+        end
+      end
+
+      class Sequence < IIIFService
+        def canvases
+          inner_hash['canvases'] || []
+        end
+
+        def canvases=(canvases)
+          inner_hash['canvases'] = canvases
+        end
+
+        def initial_attributes
+          {
+            '@type' => 'sc:Sequence'
+          }
+        end
+      end
+
+      class Canvas < IIIFService
+        def label=(label)
+          inner_hash['label'] = label
+        end
+
+        def images
+          inner_hash['images'] || []
+        end
+
+        def images=(images)
+          inner_hash['images'] = images
+        end
+
+        def initial_attributes
+          {
+            '@type' => 'sc:Canvas'
+          }
+        end
+      end
+
+      class Range < IIIFService
+        def initial_attributes
+          {
+            '@type' => 'sc:Range'
+          }
+        end
+      end
+
+      class Resource < IIIFService
+        def service=(service)
+          inner_hash['service'] = service
+        end
+
+        def initial_attributes
+          {
+            '@type' => 'sc:Range'
+          }
+        end
+      end
+
+      class Annotation < IIIFService
+        def resource=(resource)
+          inner_hash['resource'] = resource
+        end
+
+        def resource
+          inner_hash['resource']
+        end
+
+        def initial_attributes
+          {
+            '@type' => 'oa:Annotation',
+            'motivation' => 'sc:painting'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/iiif_manifest/manifest_service_locator.rb
+++ b/lib/iiif_manifest/manifest_service_locator.rb
@@ -68,7 +68,7 @@ module IIIFManifest
       end
 
       def iiif_collection_factory
-        IIIF::Presentation::Collection
+        IIIFManifest::ManifestBuilder::IIIFManifest::Collection
       end
 
       def composite_builder
@@ -108,7 +108,7 @@ module IIIFManifest
       end
 
       def sequence_factory
-        IIIF::Presentation::Sequence
+        IIIFManifest::ManifestBuilder::IIIFManifest::Sequence
       end
 
       def canvas_builder_factory
@@ -157,27 +157,27 @@ module IIIFManifest
       end
 
       def iiif_service_factory
-        IIIF::Service
+        IIIFManifest::ManifestBuilder::IIIFService
       end
 
       def iiif_resource_factory
-        IIIF::Presentation::Resource
+        IIIFManifest::ManifestBuilder::IIIFManifest::Resource
       end
 
       def iiif_annotation_factory
-        IIIF::Presentation::Annotation
+        IIIFManifest::ManifestBuilder::IIIFManifest::Annotation
       end
 
       def iiif_manifest_factory
-        IIIF::Presentation::Manifest
+        IIIFManifest::ManifestBuilder::IIIFManifest
       end
 
       def iiif_canvas_factory
-        IIIF::Presentation::Canvas
+        IIIFManifest::ManifestBuilder::IIIFManifest::Canvas
       end
 
       def iiif_range_factory
-        IIIF::Presentation::Range
+        IIIFManifest::ManifestBuilder::IIIFManifest::Range
       end
     end
 

--- a/spec/lib/iiif_manifest/manifest_builder/resource_builder_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_builder/resource_builder_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe IIIFManifest::ManifestBuilder::ResourceBuilder do
   let(:builder) do
     described_class.new(
       display_image,
-      iiif_resource_factory: IIIF::Presentation::Resource,
+      iiif_resource_factory: IIIFManifest::ManifestBuilder::IIIFManifest::Resource,
       image_service_builder_factory: image_service_builder_factory
     )
   end
   let(:url) { 'http://example.com/img1' }
   let(:display_image) { IIIFManifest::DisplayImage.new(url, width: 640, height: 480) }
-  let(:annotation) { IIIF::Presentation::Annotation.new }
+  let(:annotation) { IIIFManifest::ManifestBuilder::IIIFManifest::Annotation.new }
   let(:image_service_builder_factory) { IIIFManifest::ManifestServiceLocator.image_service_builder_factory }
 
   describe '#apply' do
@@ -19,7 +19,7 @@ RSpec.describe IIIFManifest::ManifestBuilder::ResourceBuilder do
     context 'without iiif_endpoint' do
       it 'sets a resource on the annotation' do
         subject
-        expect(annotation.resource).to be_kind_of IIIF::Presentation::Resource
+        expect(annotation.resource).to be_kind_of IIIFManifest::ManifestBuilder::IIIFManifest::Resource
         expect(annotation.resource['@id']).to eq url
         expect(annotation.resource['@type']).to eq 'dctypes:Image'
         expect(annotation.resource).not_to have_key 'service'
@@ -34,10 +34,10 @@ RSpec.describe IIIFManifest::ManifestBuilder::ResourceBuilder do
 
       it 'sets a resource on the annotation' do
         subject
-        expect(annotation.resource).to be_kind_of IIIF::Presentation::Resource
+        expect(annotation.resource).to be_kind_of IIIFManifest::ManifestBuilder::IIIFManifest::Resource
         expect(annotation.resource['@id']).to eq url
         expect(annotation.resource['@type']).to eq 'dctypes:Image'
-        expect(annotation.resource['service']).to be_kind_of IIIF::Service
+        expect(annotation.resource['service']).to be_kind_of IIIFManifest::ManifestBuilder::IIIFService
       end
     end
   end


### PR DESCRIPTION
Speeds up this library significantly for larger manifests and removes
the dependency on IIIF::Presentation.