### PR TITLE
Add search_service and autocomplete_service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Additionally it ***should*** implement `#manifest_url` that shows where the mani
 
 Additionally it ***should*** implement `#manifest_metadata` to provide an array containing hashes of metadata Label/Value pairs. 
 
-Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`). 
+Additionally it ***may*** implement `#search_service` to contain the url for an IIIF search api compliant search endpoint and `#autocomplete_service` to contain the url for an IIIF search api compliant autocomplete endpoint. Please note, the autocomplete service is embedded within the search service description so if an autocomplete_service is supplied without a search_service it will be ignored. The IIIF `profile` added to the service descriptions is version 0 as this is the version supported by the current version of Universal Viewer. Only include a search_service within the manifest if your application has impelmented an IIIF search service at the endpoint specified in the manifest. 
+
+Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`).
 
 Finally, It ***may*** implement `ranges`, which returns an array of objects which
 represent a table of contents or similar structure, each of which responds to
@@ -49,6 +51,14 @@ For example:
             { "label" => "Title", "value" => "Title of the Item" },
             { "label" => "Creator", "value" => "Morrissey, Stephen Patrick" }
           ]
+    end
+    
+    def search_service
+      "http://test.host/books/#{@id}/search"
+    end
+    
+    def autocomplete_service
+      "http://test.host/books/#{@id}/autocomplete"
     end
 
     def sequence_rendering

--- a/lib/iiif_manifest/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/manifest_builder/iiif_service.rb
@@ -53,6 +53,14 @@ module IIIFManifest
         inner_hash['metadata'] = metadata
       end
 
+      def service
+        inner_hash['service'] || []
+      end
+
+      def service=(service)
+        inner_hash['service'] = service
+      end
+
       def see_also=(see_also)
         inner_hash['seeAlso'] = see_also
       end
@@ -146,6 +154,41 @@ module IIIFManifest
           {
             '@type' => 'oa:Annotation',
             'motivation' => 'sc:painting'
+          }
+        end
+      end
+
+      class SearchService < IIIFService
+        def service=(service)
+          inner_hash['service'] = service
+        end
+
+        def search_service=(search_service)
+          inner_hash['@id'] = search_service
+        end
+
+        def initial_attributes
+          {
+            '@context' => 'http://iiif.io/api/search/0/context.json',
+            'profile' => 'http://iiif.io/api/search/0/search',
+            'label' => 'Search within this manifest'
+          }
+        end
+      end
+
+      class AutocompleteService < IIIFService
+        def autocomplete_service
+          inner_hash['@id']
+        end
+
+        def autocomplete_service=(autocomplete_service)
+          inner_hash['@id'] = autocomplete_service
+        end
+
+        def initial_attributes
+          {
+            'profile' => 'http://iiif.io/api/search/0/autocomplete',
+            'label' => 'Get suggested words in this manifest'
           }
         end
       end

--- a/lib/iiif_manifest/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/record_property_builder.rb
@@ -1,9 +1,11 @@
 module IIIFManifest
   class ManifestBuilder
     class RecordPropertyBuilder
-      attr_reader :record, :path
-      def initialize(record)
+      attr_reader :record, :iiif_search_service_factory, :iiif_autocomplete_service_factory
+      def initialize(record, iiif_search_service_factory:, iiif_autocomplete_service_factory:)
         @record = record
+        @iiif_search_service_factory = iiif_search_service_factory
+        @iiif_autocomplete_service_factory = iiif_autocomplete_service_factory
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -14,6 +16,7 @@ module IIIFManifest
         manifest.viewing_hint = viewing_hint if viewing_hint.present?
         manifest.viewing_direction = viewing_direction if viewing_direction.present?
         manifest.metadata = record.manifest_metadata if valid_metadata?
+        manifest.service = services if search_service.present?
         manifest
       end
       # rubocop:enable Metrics/AbcSize
@@ -26,6 +29,33 @@ module IIIFManifest
 
       def viewing_direction
         (record.respond_to?(:viewing_direction) && record.send(:viewing_direction))
+      end
+
+      def autocomplete_service
+        (record.respond_to?(:autocomplete_service) && record.send(:autocomplete_service))
+      end
+
+      def search_service
+        (record.respond_to?(:search_service) && record.send(:search_service))
+      end
+
+      def iiif_search_service
+        @iiif_search_service ||= iiif_search_service_factory.new
+      end
+
+      def iiif_autocomplete_service
+        @iiif_autocomplete_service ||= iiif_autocomplete_service_factory.new
+      end
+
+      # Build services. Currently supported:
+      #   search_service, with (optional) embedded autocomplete service
+      #
+      # @return [Array] array of services
+      def services
+        iiif_search_service.search_service = search_service
+        iiif_autocomplete_service.autocomplete_service = autocomplete_service
+        iiif_search_service.service = iiif_autocomplete_service if autocomplete_service.present?
+        [iiif_search_service]
       end
 
       # Validate manifest_metadata against the IIIF spec format for metadata

--- a/lib/iiif_manifest/manifest_service_locator.rb
+++ b/lib/iiif_manifest/manifest_service_locator.rb
@@ -80,7 +80,11 @@ module IIIFManifest
       end
 
       def record_property_builder
-        ManifestBuilder::RecordPropertyBuilder
+        InjectedFactory.new(
+          ManifestBuilder::RecordPropertyBuilder,
+          iiif_search_service_factory: iiif_search_service_factory,
+          iiif_autocomplete_service_factory: iiif_autocomplete_service_factory
+        )
       end
 
       def structure_builder
@@ -178,6 +182,14 @@ module IIIFManifest
 
       def iiif_range_factory
         IIIFManifest::ManifestBuilder::IIIFManifest::Range
+      end
+
+      def iiif_search_service_factory
+        IIIFManifest::ManifestBuilder::IIIFManifest::SearchService
+      end
+
+      def iiif_autocomplete_service_factory
+        IIIFManifest::ManifestBuilder::IIIFManifest::AutocompleteService
       end
     end
 

--- a/spec/lib/iiif_manifest/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_factory_spec.rb
@@ -192,6 +192,66 @@ RSpec.describe IIIFManifest::ManifestFactory do
       end
     end
 
+    context 'when there is no search_service method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a service element' do
+        allow(IIIFManifest::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there is a search_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+
+      it 'has a service element with the correct profile, @id and without an embedded service element' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service'][0]['profile']).to eq 'http://iiif.io/api/search/0/search'
+        expect(result['service'][0]['@id']).to eq 'http://test.host/books/book-77/search'
+        expect(result['service'][0]['service']).to eq nil
+      end
+    end
+
+    context 'when there is a search_service method that returns nil' do
+      let(:search_service) { '' }
+
+      it 'has no service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there is an autocomplete_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+      let(:autocomplete_service) { 'http://test.host/books/book-77/autocomplete' }
+
+      it 'has a service element within the first service containing @id and profile for the autocomplete service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
+        expect(result['service'][0]['service']['@id']).to eq 'http://test.host/books/book-77/autocomplete'
+        expect(result['service'][0]['service']['profile']).to eq 'http://iiif.io/api/search/0/autocomplete'
+      end
+    end
+
+    context 'when there is no autocomplete_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+
+      it 'has a service element within the first service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service'][0]['service']).to eq nil
+      end
+    end
+
+    context 'when there is an autocomplete_service method but no search service' do
+      let(:autocomplete_service) { 'http://test.host/books/book-77/autocomplete' }
+
+      it 'has a service element within the first service' do
+        allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
+        expect(result['service']).to eq nil
+      end
+    end
+
     context 'when there are child works' do
       let(:child_work_presenter) { presenter_class.new('test2') }
 


### PR DESCRIPTION
This PR adds two new methods: `search_service` and  `autocomplete_service` to support the addition of a service block to the presentation manifest containing a search service, and autocomplete service.

The autocomplete service is (as per the IIIF Search API) added within the search service and so if an autocomplete service is supplied without a search service, it will be ignored.

I've added information the README and tried to make it clear that including these services should only happen if the application has implemented the iiif search service.

Note: I have pinned the profile version to `0` because this is what UV supports. An enhancement would be to make this configurable.

```
"service": [
{
  "@context": "http://iiif.io/api/search/0/context.json",
  "profile": "http://iiif.io/api/search/0/search",
  "label": "Search within this manifest",
  "@id": "http://test.host/books/1234/search",
  "service": {
    "profile": "http://iiif.io/api/search/0/autocomplete",
    "label": "Get suggested words in this manifest",
    "@id": "http://test.host/books/1234/search/autocomplete"
  }
}
```