### PR TITLE
[WIP] Presentation 3.0 Alpha

### DIFF
--- a/lib/iiif_manifest/iiif_collection.rb
+++ b/lib/iiif_manifest/iiif_collection.rb
@@ -1,6 +1,8 @@
-class IIIFCollection < SimpleDelegator
-  def viewing_hint
-    return super if __getobj__.respond_to?(:viewing_hint)
-    'multi-part'
+module IIIFManifest
+  class IIIFCollection < SimpleDelegator
+    def viewing_hint
+      return super if __getobj__.respond_to?(:viewing_hint)
+      'multi-part'
+    end
   end
 end

--- a/lib/iiif_manifest/v3.rb
+++ b/lib/iiif_manifest/v3.rb
@@ -1,15 +1,10 @@
-require 'iiif_manifest/version'
 require 'active_support'
 require 'active_support/core_ext/module'
 require 'active_support/core_ext/object'
 
-module IIIFManifest
+module IIIFManifest::V3
   extend ActiveSupport::Autoload
   autoload :ManifestBuilder
   autoload :ManifestFactory
   autoload :ManifestServiceLocator
-  autoload :DisplayImage
-  autoload :IIIFCollection
-  autoload :IIIFEndpoint
-  autoload :V3
 end

--- a/lib/iiif_manifest/v3/manifest_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder.rb
@@ -1,0 +1,32 @@
+require_relative 'manifest_builder/iiif_service'
+require_relative 'manifest_builder/canvas_builder'
+require_relative 'manifest_builder/record_property_builder'
+
+module IIIFManifest::V3
+  class ManifestBuilder
+    attr_reader :work,
+                :builders,
+                :top_record_factory
+    def initialize(work, builders:, top_record_factory:)
+      @work = work
+      @builders = builders
+      @top_record_factory = top_record_factory
+    end
+
+    def apply(collection)
+      collection['manifests'] ||= []
+      collection['manifests'] << to_h
+      collection
+    end
+
+    def to_h
+      @to_h ||= builders.new(work).apply(top_record)
+    end
+
+    private
+
+    def top_record
+      top_record_factory.new
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -1,0 +1,17 @@
+module IIIFManifest::V3
+  class ManifestBuilder
+    class CanvasBuilder < ::IIIFManifest::ManifestBuilder::CanvasBuilder
+      def apply(items)
+        return items if canvas.images.blank?
+        items += [canvas]
+      end
+
+      private
+
+      def apply_record_properties
+        canvas['id'] = path
+        canvas.label = record.to_s
+      end
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -1,0 +1,168 @@
+module IIIFManifest::V3
+  class ManifestBuilder
+     class IIIFService < IIIFManifest::ManifestBuilder::IIIFService
+     end
+     
+     class IIIFManifest < IIIFService
+      def label
+        inner_hash['label']
+      end
+
+      def label=(label)
+        inner_hash['label'] = label
+      end
+
+      def summary=(summary)
+        return unless summary.present?
+        inner_hash['summary'] = summary
+      end
+
+      def viewing_direction=(viewing_direction)
+        return unless viewing_direction.present?
+        inner_hash['viewingDirection'] = viewing_direction
+      end
+
+      def viewingDirection
+        inner_hash['viewingDirection']
+      end
+
+      def items
+        inner_hash['items'] || []
+      end
+
+      def items=(items)
+        inner_hash['items'] = items
+      end
+
+      def metadata=(metadata)
+        inner_hash['metadata'] = metadata
+      end
+
+      def service
+        inner_hash['service'] || []
+      end
+
+      def service=(service)
+        inner_hash['service'] = service
+      end
+
+      def see_also=(see_also)
+        inner_hash['seeAlso'] = see_also
+      end
+
+      def rights=(rights)
+        inner_hash['rights'] = rights
+      end
+
+      def initial_attributes
+        {
+          '@context' => [
+            "http://www.w3.org/ns/anno.jsonld",
+            "http://iiif.io/api/presentation/3/context.json"
+          ],
+          'type' => 'Manifest'
+        }
+      end
+
+      class Collection < IIIFManifest
+        def initial_attributes
+          {
+            '@context' => [
+              "http://www.w3.org/ns/anno.jsonld",
+              "http://iiif.io/api/presentation/3/context.json"
+            ],
+            'type' => 'Collection'
+          }
+        end
+
+        def viewing_direction=(viewing_direction)
+          raise NotImplementedError
+        end
+
+        def viewingDirection
+          raise NotImplementedError
+        end
+      end
+
+      class Canvas < IIIFService
+        def label=(label)
+          inner_hash['label'] = label
+        end
+
+        def items
+          inner_hash['items'] || []
+        end
+
+        def items=(items)
+          inner_hash['items'] = items
+        end
+
+        def initial_attributes
+          {
+            'type' => 'Canvas'
+          }
+        end
+      end
+
+      class Range < IIIFService
+        def initial_attributes
+          {
+            'type' => 'Range'
+          }
+        end
+      end
+
+      class Annotation < IIIFService
+        def body=(body)
+          inner_hash['body'] = body
+        end
+
+        def body
+          inner_hash['body']
+        end
+
+        def initial_attributes
+          {
+            'type' => 'Annotation',
+            'motivation' => 'painting'
+          }
+        end
+      end
+
+      class SearchService < IIIFService
+        def service=(service)
+          inner_hash['service'] = service
+        end
+
+        def search_service=(search_service)
+          inner_hash['id'] = search_service
+        end
+
+        def initial_attributes
+          {
+            '@context' => 'http://iiif.io/api/search/1/context.json',
+            'profile' => 'http://iiif.io/api/search/1/search',
+            'label' => 'Search within this manifest'
+          }
+        end
+      end
+
+      class AutocompleteService < IIIFService
+        def autocomplete_service
+          inner_hash['id']
+        end
+
+        def autocomplete_service=(autocomplete_service)
+          inner_hash['id'] = autocomplete_service
+        end
+
+        def initial_attributes
+          {
+            'profile' => 'http://iiif.io/api/search/1/autocomplete',
+            'label' => 'Get suggested words in this manifest'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -1,0 +1,18 @@
+module IIIFManifest::V3
+  class ManifestBuilder
+    class RecordPropertyBuilder < ::IIIFManifest::ManifestBuilder::RecordPropertyBuilder
+      # rubocop:disable Metrics/AbcSize
+      def apply(manifest)
+        manifest['id'] = record.manifest_url.to_s
+        manifest.label = record.to_s
+        manifest.summary = record.description
+        manifest.viewing_hint = viewing_hint if viewing_hint.present?
+        manifest.viewing_direction = viewing_direction if viewing_direction.present?
+        manifest.metadata = record.manifest_metadata if valid_metadata?
+        manifest.service = services if search_service.present?
+        manifest
+      end
+      # rubocop:enable Metrics/AbcSize
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_factory.rb
+++ b/lib/iiif_manifest/v3/manifest_factory.rb
@@ -1,0 +1,36 @@
+module IIIFManifest::V3
+  class ManifestFactory
+    class << self
+      def new(work, manifest_service_locator: ManifestServiceLocator)
+        super(manifest_service_locator).new(work)
+      end
+    end
+
+    delegate :collection_manifest_builder, :manifest_builder, :sammelband_manifest_builder,
+             to: :manifest_service_locator
+    attr_reader :manifest_service_locator
+
+    def initialize(manifest_service_locator)
+      @manifest_service_locator = manifest_service_locator
+    end
+
+    def new(work)
+      if !work.work_presenters.empty?
+        if sammelband?(work) || !work.file_set_presenters.empty?
+          sammelband_manifest_builder.new(work)
+        elsif work.file_set_presenters.empty?
+          work = IIIFManifest::IIIFCollection.new(work)
+          collection_manifest_builder.new(work)
+        end
+      else
+        manifest_builder.new(work)
+      end
+    end
+
+    private
+
+    def sammelband?(work)
+      work.respond_to?(:sammelband?) && work.sammelband?
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_service_locator.rb
+++ b/lib/iiif_manifest/v3/manifest_service_locator.rb
@@ -1,0 +1,82 @@
+module IIIFManifest::V3
+  class ManifestServiceLocator < IIIFManifest::ManifestServiceLocator
+    class << self
+      # Builders which receive a work as an argument to .new and return objects
+      #   that respond to #apply.
+      def manifest_builders
+        composite_builder_factory.new(
+          record_property_builder,
+          structure_builder,
+          composite_builder: composite_builder
+        )
+      end
+
+      def sammelband_manifest_builders
+        composite_builder_factory.new(
+          record_property_builder,
+          composite_builder: composite_builder
+        )
+      end
+
+      def collection_manifest_builders
+        composite_builder_factory.new(
+          record_property_builder,
+          child_manifest_builder_factory,
+          composite_builder: composite_builder
+        )
+      end
+
+      def iiif_collection_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::Collection
+      end
+
+      def record_property_builder
+        IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
+          ManifestBuilder::RecordPropertyBuilder,
+          iiif_search_service_factory: iiif_search_service_factory,
+          iiif_autocomplete_service_factory: iiif_autocomplete_service_factory
+        )
+      end
+
+      def sequence_builder
+        raise NotImplementedError
+      end
+
+      def sammelband_sequence_builder
+        raise NotImplementedError
+      end
+
+      def sequence_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::Sequence
+      end
+
+      def iiif_service_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFService
+      end
+
+      def iiif_annotation_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::Annotation
+      end
+
+      def iiif_manifest_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest
+      end
+
+      def iiif_canvas_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas
+      end
+
+      def iiif_range_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::Range
+      end
+
+      def iiif_search_service_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::SearchService
+      end
+
+      def iiif_autocomplete_service_factory
+        IIIFManifest::V3::ManifestBuilder::IIIFManifest::AutocompleteService
+      end
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -1,0 +1,333 @@
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::V3::ManifestFactory do
+  subject { described_class.new(book_presenter) }
+
+  let(:presenter_class) { Book }
+  let(:book_presenter) { presenter_class.new('book-77') }
+
+  before do
+    class Book
+      def initialize(id)
+        @id = id
+      end
+
+      def description
+        'a brief description'
+      end
+
+      def file_set_presenters
+        []
+      end
+
+      def work_presenters
+        []
+      end
+
+      def manifest_url
+        "http://test.host/books/#{@id}/manifest"
+      end
+
+      def ranges
+        @ranges ||=
+          [
+            ManifestRange.new(label: 'Table of Contents', ranges: [
+                                ManifestRange.new(label: 'Chapter 1', file_set_presenters: [])
+                              ])
+          ]
+      end
+    end
+
+    class ManifestRange
+      attr_reader :label, :ranges, :file_set_presenters
+      def initialize(label:, ranges: [], file_set_presenters: [])
+        @label = label
+        @ranges = ranges
+        @file_set_presenters = file_set_presenters
+      end
+    end
+
+    class DisplayImagePresenter
+      def id
+        'test-22'
+      end
+
+      def display_image
+        IIIFManifest::DisplayImage.new(id, width: 100, height: 100, format: 'image/jpeg')
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :DisplayImagePresenter)
+    Object.send(:remove_const, :Book)
+  end
+
+  describe '#to_h' do
+    let(:result) { subject.to_h }
+    let(:json_result) { JSON.parse(subject.to_h.to_json) }
+
+    it 'has a label' do
+      expect(result.label).to eq book_presenter.to_s
+    end
+    it 'has an ID' do
+      expect(result['@id']).to eq 'http://test.host/books/book-77/manifest'
+    end
+
+    context 'when there are no files' do
+      it 'returns no sequences' do
+        expect(result['sequences']).to eq nil
+      end
+    end
+
+    context 'when there is a fileset' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'returns a sequence' do
+        allow(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+
+        result
+
+        expect(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to have_received(:new)
+          .exactly(1).times.with(file_presenter, anything, anything)
+      end
+      it 'builds a structure if it can' do
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        allow(book_presenter.ranges[0].ranges[0]).to receive(:file_set_presenters).and_return([file_presenter])
+
+        expect(result['structures'].length).to eq 2
+        structure = result['structures'].first
+        expect(structure['label']).to eq 'Table of Contents'
+        expect(structure['viewingHint']).to eq 'top'
+        expect(structure['canvases']).to be_blank
+        expect(structure['ranges'].length).to eq 1
+        expect(structure['ranges'][0]).not_to eq structure['@id']
+
+        sub_range = result['structures'].last
+        expect(sub_range['ranges']).to be_blank
+        expect(sub_range['canvases'].length).to eq 1
+      end
+    end
+
+    context 'when there is a no sequence_rendering method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a rendering on the sequence' do
+        allow(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['sequences'][0]['rendering']).to eq []
+      end
+    end
+
+    context 'when there is a sequence_rendering method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      before do
+        class Book
+          def initialize(id)
+            @id = id
+          end
+
+          def description
+            'a brief description'
+          end
+
+          def file_set_presenters
+            []
+          end
+
+          def work_presenters
+            []
+          end
+
+          def manifest_url
+            "http://test.host/books/#{@id}/manifest"
+          end
+
+          def sequence_rendering
+            [{ '@id' => 'http://test.host/file_set/id/download',
+               'format' => 'application/pdf',
+               'label' => 'Download' }]
+          end
+        end
+      end
+
+      it 'has a rendering on the sequence' do
+        allow(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+
+        expect(result['sequences'][0]['rendering']).to eq [{
+          '@id' => 'http://test.host/file_set/id/download', 'format' => 'application/pdf', 'label' => 'Download'
+        }]
+      end
+    end
+
+    context 'when there is no manifest_metadata method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a metadata element' do
+        allow(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['metadata']).to eq nil
+      end
+    end
+
+    context 'when there is a manifest_metadata method' do
+      let(:metadata) { [{ 'label' => 'Title', 'value' => 'Title of the Item' }] }
+
+      it 'has metadata' do
+        allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
+        expect(result['metadata'][0]['label']).to eq 'Title'
+        expect(result['metadata'][0]['value']).to eq 'Title of the Item'
+      end
+    end
+
+    context 'when there is a manifest_metadata method with invalid data' do
+      let(:metadata) { 'invalid data' }
+
+      it 'has no metadata' do
+        allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
+        expect(result['metadata']).to eq nil
+      end
+    end
+
+    context 'when there is no search_service method' do
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      it 'does not have a service element' do
+        allow(IIIFManifest::V3::ManifestBuilder::CanvasBuilder).to receive(:new).and_call_original
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there is a search_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+
+      it 'has a service element with the correct profile, @id and without an embedded service element' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service'][0]['profile']).to eq 'http://iiif.io/api/search/0/search'
+        expect(result['service'][0]['@id']).to eq 'http://test.host/books/book-77/search'
+        expect(result['service'][0]['service']).to eq nil
+      end
+    end
+
+    context 'when there is a search_service method that returns nil' do
+      let(:search_service) { '' }
+
+      it 'has no service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there is an autocomplete_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+      let(:autocomplete_service) { 'http://test.host/books/book-77/autocomplete' }
+
+      it 'has a service element within the first service containing @id and profile for the autocomplete service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
+        expect(result['service'][0]['service']['@id']).to eq 'http://test.host/books/book-77/autocomplete'
+        expect(result['service'][0]['service']['profile']).to eq 'http://iiif.io/api/search/0/autocomplete'
+      end
+    end
+
+    context 'when there is no autocomplete_service method' do
+      let(:search_service) { 'http://test.host/books/book-77/search' }
+
+      it 'has a service element within the first service' do
+        allow(book_presenter).to receive(:search_service).and_return(search_service)
+        expect(result['service'][0]['service']).to eq nil
+      end
+    end
+
+    context 'when there is an autocomplete_service method but no search service' do
+      let(:autocomplete_service) { 'http://test.host/books/book-77/autocomplete' }
+
+      it 'has a service element within the first service' do
+        allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
+        expect(result['service']).to eq nil
+      end
+    end
+
+    context 'when there are child works' do
+      let(:child_work_presenter) { presenter_class.new('test2') }
+
+      before do
+        allow(book_presenter).to receive(:work_presenters).and_return([child_work_presenter])
+      end
+      it 'returns a IIIF Collection' do
+        expect(result['@type']).to eq 'sc:Collection'
+      end
+      it "doesn't build sequences" do
+        expect(result['sequences']).to eq nil
+      end
+      it 'has a multi-part viewing hint' do
+        expect(json_result['viewingHint']).to eq 'multi-part'
+      end
+      it 'builds child manifests' do
+        expect(result['manifests'].length).to eq 1
+        first_child = result['manifests'].first
+        expect(first_child['@id']).to eq 'http://test.host/books/test2/manifest'
+        expect(first_child['@type']).to eq 'sc:Manifest'
+        expect(first_child['label']).to eq child_work_presenter.to_s
+      end
+    end
+
+    context 'when there are child works AND files' do
+      let(:child_work_presenter) { presenter_class.new('test-99') }
+      let(:file_presenter) { DisplayImagePresenter.new }
+      let(:file_presenter2) { DisplayImagePresenter.new }
+
+      before do
+        allow(book_presenter).to receive(:work_presenters).and_return([child_work_presenter])
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+        allow(child_work_presenter).to receive(:file_set_presenters).and_return([file_presenter2])
+      end
+      it 'returns a IIIF Manifest' do
+        expect(result['@type']).to eq 'sc:Manifest'
+      end
+      it "doesn't build manifests" do
+        expect(result['manifests']).to eq nil
+      end
+      it 'builds sequences from all the child file sets' do
+        expect(result['sequences'].first['canvases'].length).to eq 2
+      end
+    end
+
+    context 'when there are child works AMD when the work identifies itself as a sammelband' do
+      let(:child_work_presenter) { presenter_class.new('test-99') }
+      let(:file_presenter) { DisplayImagePresenter.new }
+
+      before do
+        allow(book_presenter).to receive(:sammelband?).and_return(true)
+        allow(book_presenter).to receive(:work_presenters).and_return([child_work_presenter])
+        allow(child_work_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+      end
+      it 'returns a IIIF Manifest' do
+        expect(result['@type']).to eq 'sc:Manifest'
+      end
+      it "doesn't build manifests" do
+        expect(result['manifests']).to eq nil
+      end
+      it 'builds sequences from all the child file sets' do
+        expect(result['sequences'].first['canvases'].length).to eq 1
+      end
+    end
+
+    context 'when there is no viewing_direction method' do
+      it 'does not have a viewingDirection element' do
+        expect(result['viewingDirection']).to eq nil
+      end
+    end
+
+    context 'when there is a viewing_direction method' do
+      it 'has a viewingDirection' do
+        allow(book_presenter).to receive(:viewing_direction).and_return('right-to-left')
+        expect(result.viewingDirection).to eq 'right-to-left'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for IIIF Presentation 3.0 Alpha (as of 3/23/2018).  Given that clients which consume the manifest will take time to support 3.0 manifests, the approach taken in this PR is to create a new namespace (`V3`) that subclasses and overwrites as necessary the existing classes that target 2.0 instead of updating in place.  To generate Presentation 3.0 manifests, use the `IIIFManifest::V3::ManifestFactory` instead of `IIIFManifest::ManifestFactory` passing the same presenters.

See http://prezi3.iiif.io/api/presentation/3.0 for more details on how the manifests generated will be different than the default V2 manifests.

Other changes in the PR:
- Explicitly wrapping IIIFCollection in the IIIFManifest module

TODO:
- Fix tests
- Write new tests
- Verify output by running 2.0 manifest through converter (https://github.com/IIIF/prezi-2-to-3) and compare with generated 3.0 manifest
- Add support for AV material as needed by Avalon