### PR TITLE
V3 Range Improvements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,18 +36,22 @@ RSpec/NamedSubject:
     - 'spec/lib/iiif_manifest/iiif_endpoint_spec.rb'
     - 'spec/lib/iiif_manifest/manifest_builder/resource_builder_spec.rb'
     - 'spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb'
+    - 'spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/lib/iiif_manifest/display_image_spec.rb'
+    - 'spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb'
+    - 'spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb'
 
 RSpec/ExampleLength:
   Exclude:
     - 'spec/lib/iiif_manifest/manifest_factory_spec.rb'
     - 'spec/lib/iiif_manifest/v3/manifest_factory_spec.rb'
     - 'spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb'
+    - 'spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb'
 
 # Offense count: 20
 Style/Documentation:

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -31,6 +31,7 @@ module IIIFManifest
         def path
           path = "#{parent.manifest_url}/canvas/#{record.id}"
           path << "##{record.media_fragment}" if record.respond_to?(:media_fragment)
+          path
         end
 
         def apply(items)

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -29,7 +29,8 @@ module IIIFManifest
         end
 
         def path
-          "#{parent.manifest_url}/canvas/#{record.id}"
+          path = "#{parent.manifest_url}/canvas/#{record.id}"
+          path << "##{record.media_fragment}" if record.respond_to?(:media_fragment)
         end
 
         def apply(items)

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
+  let(:builder) do
+    described_class.new(
+      record,
+      parent,
+      iiif_canvas_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas,
+      content_builder: IIIFManifest::V3::ManifestBuilder::ContentBuilder,
+      choice_builder: IIIFManifest::V3::ManifestBuilder::ChoiceBuilder,
+      iiif_annotation_page_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
+    )
+  end
+  let(:record) { double(id: 'test-22') }
+  let(:parent) { double(manifest_url: 'http://test.host/books/book-77/manifest') }
+
+  describe '#path' do
+    it 'returns a canvas url' do
+      expect(builder.path).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
+    end
+
+    context 'when media_fragment is defined' do
+      before do
+        allow(record).to receive(:media_fragment).and_return('xywh=160,120,320,240')
+      end
+      it 'returns a canvas url' do
+        expect(builder.path).to eq 'http://test.host/books/book-77/manifest/canvas/test-22#xywh=160,120,320,240'
+      end
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
+  let(:builder) do
+    described_class.new(
+      record,
+      canvas_builder_factory: IIIFManifest::ManifestServiceLocator.canvas_builder,
+      iiif_range_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Range
+    )
+  end
+  let(:ranges) do
+    []
+  end
+  let(:record) { double(manifest_url: 'http://test.host/books/book-77/manifest', ranges: ranges) }
+  let(:manifest) { IIIFManifest::V3::ManifestBuilder::IIIFManifest.new }
+
+  describe '#apply' do
+    subject { builder.apply(manifest) }
+
+    it 'returns a canvas url' do
+      subject
+      expect(manifest['structures']).to eq nil
+    end
+
+    context 'with ranges and file set presenters defined' do
+      let(:ranges) do
+        [
+          ManifestRange.new(label: 'Table of Contents', ranges: [
+                              ManifestRange.new(label: 'Chapter 1', file_set_presenters: file_set_presenters)
+                            ],
+                            file_set_presenters: [double(id: 'Front-Cover')])
+        ]
+      end
+      let(:file_set_presenters) { [double(id: 'Page-1'), double(id: 'Page-2')] }
+
+      before do
+        class ManifestRange
+          attr_reader :label, :ranges, :file_set_presenters
+          def initialize(label:, ranges: [], file_set_presenters: [])
+            @label = label
+            @ranges = ranges
+            @file_set_presenters = file_set_presenters
+          end
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :ManifestRange)
+      end
+
+      it 'builds the structure' do
+        subject
+        top_range = manifest['structures'].first
+        expect(top_range['label']).to eq 'Table of Contents'
+        expect(top_range['behavior']).to eq 'top'
+        expect(top_range['items'].length).to eq 2
+        expect(top_range['items'][0]['type']).to eq 'Canvas'
+        expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
+        expect(top_range['items'][1]['type']).to eq 'Range'
+        sub_range = top_range['items'][1]
+        expect(sub_range['items'].length).to eq 2
+        expect(sub_range['items'][0]['type']).to eq 'Canvas'
+        expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'
+        expect(sub_range['items'][1]['type']).to eq 'Canvas'
+        expect(sub_range['items'][1]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-2'
+      end
+    end
+
+    context 'with items defined' do
+      let(:ranges) do
+        [
+          ManifestRange.new(label: 'Table of Contents', items: [
+                              double(id: 'Front-Cover'),
+                              ManifestRange.new(label: 'Chapter 1', items: [
+                                                  double(id: 'Page-1'),
+                                                  double(id: 'Page-2')
+                                                ]),
+                              double(id: 'Back-Cover')
+                            ])
+        ]
+      end
+
+      before do
+        class ManifestRange
+          attr_reader :label, :items
+          def initialize(label:, items: [])
+            @label = label
+            @items = items
+          end
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :ManifestRange)
+      end
+
+      it 'builds the structure' do
+        subject
+        top_range = manifest['structures'].first
+        expect(top_range['label']).to eq 'Table of Contents'
+        expect(top_range['behavior']).to eq 'top'
+        expect(top_range['items'].length).to eq 3
+        expect(top_range['items'][0]['type']).to eq 'Canvas'
+        expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
+        expect(top_range['items'][1]['type']).to eq 'Range'
+        sub_range = top_range['items'][1]
+        expect(sub_range['items'].length).to eq 2
+        expect(sub_range['items'][0]['type']).to eq 'Canvas'
+        expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'
+        expect(sub_range['items'][1]['type']).to eq 'Canvas'
+        expect(sub_range['items'][1]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-2'
+        expect(top_range['items'][2]['type']).to eq 'Canvas'
+        expect(top_range['items'][2]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Back-Cover'
+      end
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -67,11 +67,6 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       def display_image
         IIIFManifest::DisplayImage.new(id, width: 100, height: 100, format: 'image/jpeg')
-        # rubocop:disable Metrics/LineLength
-        # [IIIFManifest::V3::DisplayContent.new(id, type: 'Video', label: 'High', width: 100, height: 100, duration: 100, format: 'video/mp4'),
-        #  IIIFManifest::V3::DisplayContent.new(id, type: 'Video', label: 'Medium', width: 100, height: 100, duration: 100, format: 'video/mp4'),
-        #  IIIFManifest::V3::DisplayContent.new(id, type: 'Video', label: 'Low', width: 100, height: 100, duration: 100, format: 'video/mp4')]
-        # rubocop:enable Metrics/LineLength
       end
     end
   end


### PR DESCRIPTION
There are two improvements in this PR which I could break apart if requested: 
- Allow adding a media fragment to a canvas url (See paragraph starting 'Parts of Canvases MAY also be identified' at http://iiif.io/api/presentation/3.0/#53-canvas)
- Supporting interleaving of ranges and canvases within the structures.