### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/lib/iiif_manifest/version.rb
+++ b/lib/iiif_manifest/version.rb
@@ -1,3 +1,3 @@
 module IIIFManifest
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
This release will add provisional support for the IIIF Presentation 3.0 alpha spec (https://iiif.io/api/presentation/3.0/).