### PR TITLE
Optional authentication service for non-image api-backed resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Additionally it ***should*** implement `#manifest_url` that shows where the mani
 
 Additionally it ***should*** implement `#manifest_metadata` to provide an array containing hashes of metadata Label/Value pairs.
 
-Additionally it ***may*** implement `#search_service` to contain the url for an IIIF search api compliant search endpoint and `#autocomplete_service` to contain the url for an IIIF search api compliant autocomplete endpoint. Please note, the autocomplete service is embedded within the search service description so if an autocomplete_service is supplied without a search_service it will be ignored. The IIIF `profile` added to the service descriptions is version 0 as this is the version supported by the current version of Universal Viewer. Only include a search_service within the manifest if your application has impelmented an IIIF search service at the endpoint specified in the manifest.
+Additionally it ***may*** implement `#search_service` to contain the url for a IIIF search api compliant search endpoint and `#autocomplete_service` to contain the url for a IIIF search api compliant autocomplete endpoint. Please note, the autocomplete service is embedded within the search service description so if an autocomplete_service is supplied without a search_service it will be ignored. The IIIF `profile` added to the service descriptions is version 0 as this is the version supported by the current version of Universal Viewer. Only include a search_service within the manifest if your application has implemented a IIIF search service at the endpoint specified in the manifest.
 
 Additionally it ***may*** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`).
 
@@ -144,6 +144,7 @@ The presentation 3.0 support has been contained to the `V3` namespace.  Version 
 - File set presenters may target a fragment of its content by providing `#media_fragment` which will be appended to its `id`.
 - Range objects may now implement `#items` instead of `#ranges` and `#file_set_presenters` to allow for interleaving these objects.  `#items` is not required and existing range objects should continue to work.
 - File set presenters may provide `#display_content` which should return an instance of `IIIFManifest::V3::DisplayContent` (or an array of instances in the case of a user `Choice`).  `#display_image` is no longer required but will still work if provided.
+- DisplayContent may provide `#auth_service` which should return a hash containing a IIIF Authentication service definition (https://iiif.io/api/auth/1.0/) that will be included on the content resource.
 
 ## Development
 

--- a/lib/iiif_manifest/v3/display_content.rb
+++ b/lib/iiif_manifest/v3/display_content.rb
@@ -1,8 +1,10 @@
 module IIIFManifest
   module V3
     class DisplayContent
-      attr_reader :url, :width, :height, :duration, :iiif_endpoint, :format, :type, :label
-      def initialize(url, type:, width: nil, height: nil, duration: nil, label: nil, format: nil, iiif_endpoint: nil)
+      attr_reader :url, :width, :height, :duration, :iiif_endpoint, :format, :type,
+                  :label, :auth_service
+      def initialize(url, type:, width: nil, height: nil, duration: nil, label: nil,
+                     format: nil, iiif_endpoint: nil, auth_service: nil)
         @url = url
         @type = type
         @width = width
@@ -11,6 +13,7 @@ module IIIFManifest
         @label = label
         @format = format
         @iiif_endpoint = iiif_endpoint
+        @auth_service = auth_service
       end
     end
   end

--- a/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
@@ -12,6 +12,7 @@ module IIIFManifest
         def apply(annotation)
           build_body
           image_service_builder.apply(body) if iiif_endpoint
+          apply_auth_service if auth_service
           annotation.body = body
         end
 
@@ -41,6 +42,18 @@ module IIIFManifest
 
           def image_service_builder
             image_service_builder_factory.new(iiif_endpoint)
+          end
+
+          def auth_service
+            display_content.try(:auth_service)
+          end
+
+          def apply_auth_service
+            body.service = if body['service'].blank?
+                             [auth_service]
+                           else
+                             body['service'] + [auth_service]
+                           end
           end
       end
     end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -126,6 +126,57 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['format']).to eq 'video/mp4'
         end
       end
+
+      context 'with auth service' do
+        let(:auth_service) do
+          {
+            context: "http://iiif.io/api/auth/1/context.json",
+            id: "http://example.org/iiif/loginservice",
+            confirmLabel: "Login",
+            description: "...",
+            failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
+            failureHeader: "Authentication Failed",
+            header: "This material requires authorization",
+            label: "This material requires authorization",
+            profile: "http://iiif.io/api/auth/1/login",
+            service: [
+              {
+                context: "http://iiif.io/api/auth/1/context.json",
+                id: "http://example.org/iiif/token",
+                profile: "http://iiif.io/api/auth/1/token"
+              },
+              {
+                context: "http://iiif.io/api/auth/1/context.json",
+                id: "http://example.org/iiif/logout",
+                label: "Log out",
+                profile: "http://iiif.io/api/auth/1/logout"
+              }
+            ]
+          }
+        end
+        let(:display_content) do
+          IIIFManifest::V3::DisplayContent.new(url, width: 640,
+                                                    height: 480,
+                                                    duration: 1000,
+                                                    type: 'Video',
+                                                    format: 'video/mp4',
+                                                    label: 'Reel 1',
+                                                    auth_service: auth_service)
+        end
+
+        it 'sets a body on the annotation' do
+          subject
+          expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+          expect(annotation.body['id']).to eq url
+          expect(annotation.body['type']).to eq 'Video'
+          expect(annotation.body['width']).to eq 640
+          expect(annotation.body['height']).to eq 480
+          expect(annotation.body['duration']).to eq 1000
+          expect(annotation.body['label']).to eq('@none' => ['Reel 1'])
+          expect(annotation.body['format']).to eq 'video/mp4'
+          expect(annotation.body['service']).to include auth_service
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds the ability to add a IIIF auth service to a DisplayContent resource.  I didn't work on adding this to images since I don't have that use case and it should probably be provided by the IIIF image server (through the description service `info.json`).  I passed it as a giant hash for simplicity sake but am open to other approaches.

I'm using this branch in an Avalon PR here: 
https://github.com/avalonmediasystem/avalon/blob/0b7f6a04573c3ab561e13b14673a4de21c66d173/app/models/iiif_canvas_presenter.rb#L40
https://github.com/avalonmediasystem/avalon/blob/0b7f6a04573c3ab561e13b14673a4de21c66d173/app/models/iiif_canvas_presenter.rb#L125-L151