### PR TITLE
Don't include # if there isn't any media fragment

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -30,7 +30,7 @@ module IIIFManifest
 
         def path
           path = "#{parent.manifest_url}/canvas/#{record.id}"
-          path << "##{record.media_fragment}" if record.respond_to?(:media_fragment)
+          path << "##{record.media_fragment}" if record.respond_to?(:media_fragment) && record.media_fragment.present?
           path
         end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       it 'returns a canvas url' do
         expect(builder.path).to eq 'http://test.host/books/book-77/manifest/canvas/test-22#xywh=160,120,320,240'
       end
+
+      context 'and is blank' do
+        before do
+          allow(record).to receive(:media_fragment).and_return(nil)
+        end
+        it 'returns a canvas url' do
+          expect(builder.path).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If your presenter implements `#media_fragment` and returns nil when there isn't a media fragment, you can end up with a canvas with a tailing `#`.  A IIIF client that we're working with doesn't like this and it doesn't serve any purpose so this PR removes the `#` when no media fragment is present.