### PR TITLE
Ensures that empty DisplayContent values within IIIFv3 Manifest generation are handled

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,6 +22,7 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Exclude:
     - 'iiif_manifest.gemspec'
+    - 'lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb'
 
 # Offense count: 1
 # Configuration parameters: AssignmentOnly.
@@ -52,6 +53,7 @@ RSpec/ExampleLength:
     - 'spec/lib/iiif_manifest/v3/manifest_factory_spec.rb'
     - 'spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb'
     - 'spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb'
+    - 'spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb'
 
 # Offense count: 20
 Style/Documentation:

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -46,7 +46,7 @@ module IIIFManifest
           end
 
           def display_content
-            Array.wrap(record.display_content) if record.respond_to?(:display_content)
+            Array.wrap(record.display_content) if record.respond_to?(:display_content) && record.display_content.present?
           end
 
           def apply_record_properties

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
+  let(:content_builder) do
+    IIIFManifest::V3::ManifestBuilder::ContentBuilder
+  end
   let(:builder) do
     described_class.new(
       record,
       parent,
       iiif_canvas_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas,
-      content_builder: IIIFManifest::V3::ManifestBuilder::ContentBuilder,
+      content_builder: content_builder,
       choice_builder: IIIFManifest::V3::ManifestBuilder::ChoiceBuilder,
       iiif_annotation_page_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
     )
@@ -41,6 +44,145 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         it 'returns a canvas url' do
           expect(builder.path).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
         end
+      end
+    end
+  end
+
+  describe '#canvas' do
+    let(:record) do
+      MyWork.new
+    end
+
+    after do
+      Object.send(:remove_const, :MyWork)
+    end
+
+    context 'when the display content is empty for an item' do
+      before do
+        class MyWork
+          def id
+            'test-22'
+          end
+
+          def display_content
+            []
+          end
+        end
+      end
+
+      it 'generates the canvas' do
+        canvas = builder.canvas
+        expect(canvas).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas
+        values = canvas.inner_hash
+
+        expect(values).to include "type" => "Canvas"
+        expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
+
+        expect(values).to include 'items'
+        items = values['items']
+        expect(items.length).to eq 1
+        page = items.first
+        expect(page).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
+        expect(page.items).to be_empty
+      end
+    end
+
+    context 'when the display content is populated for a record' do
+      let(:url) { 'http://example.com/img1' }
+      let(:display_content) do
+        IIIFManifest::V3::DisplayContent.new(url,
+                                             width: 640,
+                                             height: 480,
+                                             type: 'Image',
+                                             format: 'image/jpeg',
+                                             label: 'full')
+      end
+      let(:record) do
+        MyWork.new(display_content: display_content)
+      end
+
+      before do
+        class MyWork
+          attr_reader :display_content
+
+          def initialize(display_content:)
+            @display_content = display_content
+          end
+
+          def id
+            'test-22'
+          end
+        end
+
+        allow(body_builder).to receive(:apply).and_return(iiif_body)
+        allow(body_builder_factory).to receive(:new).and_return(body_builder)
+        allow(iiif_annotation_factory).to receive(:new).and_return(iiif_annotation)
+        allow(content_builder).to receive(:new).and_return(built_content)
+      end
+
+      let(:iiif_body) do
+        body = IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body.new
+        body['width'] = '100px'
+        body['height'] = '100px'
+        body['duration'] = nil
+        body
+      end
+
+      let(:iiif_annotation) do
+        annotation = IIIFManifest::V3::ManifestBuilder::IIIFManifest::Annotation.new
+        annotation.body = iiif_body
+        annotation
+      end
+
+      let(:iiif_annotation_factory) do
+        double
+      end
+
+      let(:body_builder) do
+        instance_double(IIIFManifest::V3::ManifestBuilder::BodyBuilder)
+      end
+
+      let(:body_builder_factory) do
+        double
+      end
+
+      let(:built_content) do
+        IIIFManifest::V3::ManifestBuilder::ContentBuilder.new(
+          record.display_content,
+          iiif_annotation_factory: iiif_annotation_factory,
+          body_builder_factory: body_builder_factory
+        )
+      end
+
+      let(:content_builder) do
+        double
+      end
+
+      it 'generates the canvas' do
+        canvas = builder.canvas
+        expect(canvas).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas
+        values = canvas.inner_hash
+
+        expect(values).to include "type" => "Canvas"
+        expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
+
+        expect(values).to include 'items'
+        items = values['items']
+        expect(items.length).to eq 1
+        page = items.first
+        expect(page).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
+        items = page.items
+        expect(items.length).to eq 1
+        annotation = items.first
+        expect(annotation).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Annotation
+        values = annotation.inner_hash
+        expect(values).to include('body')
+        body = values['body']
+        expect(body).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+        values = body.inner_hash
+        expect(values).to include "width" => "100px"
+        expect(values).to include "height" => "100px"
+        expect(values).to include "duration" => nil
       end
     end
   end


### PR DESCRIPTION
Currently, should `DisplayContent` be accessible on `record` but empty for https://github.com/samvera-labs/iiif_manifest/blob/master/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb#L49, `#attach_content` will break (https://github.com/samvera-labs/iiif_manifest/blob/master/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb#L67)