### PR TITLE
Add initial configuration for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+---
+version: 2.1
+orbs:
+  samvera: samvera/circleci-orb@0
+
+jobs:
+ test:
+    parameters:
+      ruby_version:
+        type: string
+      rails_version:
+        type: string
+      bundler_version:
+        type: string
+        default: 1.17.2
+
+    executor:
+      name: 'samvera/ruby'
+      ruby_version: << parameters.ruby_version >>
+
+    environment:
+      COVERAGE: true
+      RAILS_VERSION: << parameters.rails_version >>
+
+    working_directory: ~/iiif_manifest
+
+    steps:
+      - samvera/cached_checkout
+      - samvera/bundle_for_gem:
+          ruby_version: << parameters.ruby_version >>
+          bundler_version: << parameters.bundler_version >>
+          project: iiif_manifest
+      - samvera/rubocop
+      - samvera/parallel_rspec
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test:
+          name: "ruby2-6_rails5-2"
+          ruby_version: "2.6.3"
+          rails_version: "5.2.3"
+      - test:
+          name: "ruby2-5_rails5-2"
+          ruby_version: "2.5.5"
+          rails_version: "5.2.3"
+      - test:
+          name: "ruby2-4_rails5-2"
+          ruby_version: "2.4.6"
+          rails_version: "5.2.3"
+      - test:
+          name: "ruby2-6_rails5-1"
+          ruby_version: "2.6.3"
+          rails_version: "5.1.7"
+      - test:
+          name: "ruby2-5_rails5-1"
+          ruby_version: "2.5.5"
+          rails_version: "5.1.7"
+      - test:
+          name: "ruby2-4_rails5-1"
+          ruby_version: "2.4.6"
+          rails_version: "5.1.7"

--- a/iiif_manifest.gemspec
+++ b/iiif_manifest.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
 end


### PR DESCRIPTION
This adds the necessary configuration to use CircleCI for continuous integration testing of the gem in anticipation of promoting it to the samvera GitHub organization. 

Curren builds of this branch:
https://circleci.com/gh/samvera-labs/iiif_manifest/tree/circle_ci