### PR TITLE
Only create a canvas thumbnail if display_content contains a thumbnail

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -100,7 +100,7 @@ module IIIFManifest
         def apply_thumbnail_to(canvas)
           if display_image
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
-          elsif display_content.try(:first)
+          elsif display_content.try(:first) && display_content.first.try(:thumbnail)
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_content.first).build)
           end
         end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
                                          type: 'Image',
                                          format: 'image/jpeg',
                                          label: 'full',
-                                         iiif_endpoint: iiif_endpoint)
+                                         iiif_endpoint: iiif_endpoint,
+                                         thumbnail: iiif_thumbnail)
   end
   let(:placeholder_content) do
     IIIFManifest::V3::DisplayContent.new(SecureRandom.uuid, type: 'Image',
@@ -694,6 +695,25 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         values = canvas.inner_hash
 
         expect(values.key?('service')).to be true
+      end
+    end
+
+    context 'when a thumbnail is not specified for a record' do
+      let(:display_content) do
+        IIIFManifest::V3::DisplayContent.new(url,
+                                         width: 640,
+                                         height: 480,
+                                         type: 'Image',
+                                         format: 'image/jpeg',
+                                         label: 'full',
+                                         iiif_endpoint: iiif_endpoint)
+      end
+
+      it 'thumbnail field is not present on the canvas' do
+        canvas = builder.canvas
+        values = canvas.inner_hash
+
+        expect(values.key?('thumbnail')).to be false
       end
     end
   end


### PR DESCRIPTION
Fix for [Avalon issue #6627](https://github.com/avalonmediasystem/avalon/issues/6627)