### PR TITLE
Allow auth_service to be array of hashes, allow override of top level context

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ The presentation 3.0 support has been contained to the `V3` namespace. Version 2
   - `#part_of` is supported at leaf node level, to present an array of parent resources available at each leaf node.
   - `#homepage` is supported at leaf node level, to present an array of homepage resources available at each leaf node.
   - `#placeholder_content` which returns an instance of `IIIFManifest::V3::DisplayContent` presents a [`placeholderCanvas`](https://iiif.io/api/presentation/3.0/#placeholdercanvas) at leaf node level
-- DisplayContent may provide `#auth_service` which should return an array containing one or more hashes defining IIIF Authentication services (<https://iiif.io/api/auth/1.0/> or <https://iiif.io/api/auth/2.0/>) that will be included on the content resource.
+  - DisplayContent may provide `#auth_service` which should return a hash containing a IIIF Authentication 1.0 service definition (<https://iiif.io/api/auth/1.0/>) that will be included on the content resource.
+  - DisplayContent may provide `#auth2_service` which should return a hash containing a IIIF Authentication 2.0 service definition (<https://iiif.io/api/auth/2.0/>) that will be included on the content resource.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The presentation 3.0 support has been contained to the `V3` namespace. Version 2
   - `#part_of` is supported at leaf node level, to present an array of parent resources available at each leaf node.
   - `#homepage` is supported at leaf node level, to present an array of homepage resources available at each leaf node.
   - `#placeholder_content` which returns an instance of `IIIFManifest::V3::DisplayContent` presents a [`placeholderCanvas`](https://iiif.io/api/presentation/3.0/#placeholdercanvas) at leaf node level
-- DisplayContent may provide `#auth_service` which should return a hash containing a IIIF Authentication service definition (<https://iiif.io/api/auth/1.0/>) that will be included on the content resource.
+- DisplayContent may provide `#auth_service` which should return an array containing one or more hashes defining IIIF Authentication services (<https://iiif.io/api/auth/1.0/> or <https://iiif.io/api/auth/2.0/>) that will be included on the content resource.
 
 ## Configuration
 

--- a/lib/iiif_manifest/v3/display_content.rb
+++ b/lib/iiif_manifest/v3/display_content.rb
@@ -2,7 +2,7 @@ module IIIFManifest
   module V3
     class DisplayContent
       attr_reader :url, :width, :height, :duration, :iiif_endpoint, :format, :type,
-                  :label, :auth_service, :thumbnail
+                  :label, :auth_service, :auth2_service, :thumbnail
       def initialize(url, type:, **kwargs)
         @url = url
         @type = type
@@ -13,6 +13,7 @@ module IIIFManifest
         @format = kwargs[:format]
         @iiif_endpoint = kwargs[:iiif_endpoint]
         @auth_service = kwargs[:auth_service]
+        @auth2_service = kwargs[:auth2_service]
         @thumbnail = kwargs[:thumbnail]
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
@@ -12,7 +12,7 @@ module IIIFManifest
         def apply(annotation)
           build_body
           image_service_builder.apply(body) if iiif_endpoint
-          apply_auth_service if auth_service
+          apply_auth_service if auth_service || auth2_service
           annotation.body = body
         end
 
@@ -63,11 +63,15 @@ module IIIFManifest
           content.try(:auth_service)
         end
 
+        def auth2_service
+          content.try(:auth2_service)
+        end
+
         def apply_auth_service
           body.service = if body['service'].blank?
-                           [auth_service].flatten
+                           [auth_service, auth2_service].compact
                          else
-                           body['service'] + [auth_service].flatten
+                           body['service'] + [auth_service, auth2_service].compact
                          end
         end
       end

--- a/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
@@ -65,9 +65,9 @@ module IIIFManifest
 
         def apply_auth_service
           body.service = if body['service'].blank?
-                           [auth_service]
+                           [auth_service].flatten
                          else
-                           body['service'] + [auth_service]
+                           body['service'] + [auth_service].flatten
                          end
         end
       end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -44,6 +44,7 @@ module IIIFManifest
         # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
+          manifest['@context'] = record.context if record.try(:context).present?
           label = ::IIIFManifest.config.manifest_value_for(record, property: :label)
           manifest.label = ManifestBuilder.language_map(label) if label.present?
           summary = ::IIIFManifest.config.manifest_value_for(record, property: :summary)

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -19,6 +19,7 @@ module IIIFManifest
           setup_manifest_from_record(manifest, record)
           # Build the items array
           canvas_builder.apply(manifest.items)
+          apply_auth2_context(manifest) if auth2?(record)
           apply_thumbnail_to(manifest) unless manifest_thumbnail?
           manifest
         end
@@ -44,7 +45,6 @@ module IIIFManifest
         # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
-          manifest['@context'] = record.context if record.try(:context).present?
           label = ::IIIFManifest.config.manifest_value_for(record, property: :label)
           manifest.label = ManifestBuilder.language_map(label) if label.present?
           summary = ::IIIFManifest.config.manifest_value_for(record, property: :summary)
@@ -101,6 +101,14 @@ module IIIFManifest
           metadata_field
         end
 
+        def apply_auth2_context(manifest)
+          manifest["@context"] = [
+            'http://www.w3.org/ns/anno.jsonld',
+            'http://iiif.io/api/auth/2/context.json',
+            'http://iiif.io/api/presentation/3/context.json'
+          ]
+        end
+
         def apply_thumbnail_to(manifest)
           if manifest.is_a? IIIFManifest::Collection
             manifest.thumbnail = manifest.items.collect(&:thumbnail).compact
@@ -111,6 +119,12 @@ module IIIFManifest
 
         def manifest_thumbnail?
           ::IIIFManifest.config.manifest_thumbnail == false
+        end
+
+        def auth2?(record)
+          # DisplayContent can be an array, so need to massage things to iterate over everything in all cases
+          content = record.file_set_presenters.map { |pres| Array(pres.try(:display_content)).compact }.flatten
+          content.any? { |item| item.try(:auth2_service).present? }
         end
       end
     end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -128,113 +128,176 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
         end
       end
 
-      context 'with auth service' do
-        let(:auth_service) do
-          {
-            context: "http://iiif.io/api/auth/1/context.json",
-            id: "http://example.org/iiif/loginservice",
-            confirmLabel: "Login",
-            description: "...",
-            failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
-            failureHeader: "Authentication Failed",
-            header: "This material requires authorization",
-            label: "This material requires authorization",
-            profile: "http://iiif.io/api/auth/1/login",
-            service: [
-              {
-                context: "http://iiif.io/api/auth/1/context.json",
-                id: "http://example.org/iiif/token",
-                profile: "http://iiif.io/api/auth/1/token"
-              },
-              {
-                context: "http://iiif.io/api/auth/1/context.json",
-                id: "http://example.org/iiif/logout",
-                label: "Log out",
-                profile: "http://iiif.io/api/auth/1/logout"
-              }
-            ]
-          }
-        end
-        let(:display_content) do
-          IIIFManifest::V3::DisplayContent.new(url, width: 640,
-                                                    height: 480,
-                                                    duration: 1000,
-                                                    type: 'Video',
-                                                    format: 'video/mp4',
-                                                    label: 'Reel 1',
-                                                    auth_service: auth_service)
-        end
-
-        it 'sets a body on the annotation' do
-          subject
-          expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
-          expect(annotation.body['id']).to eq url
-          expect(annotation.body['type']).to eq 'Video'
-          expect(annotation.body['width']).to eq 640
-          expect(annotation.body['height']).to eq 480
-          expect(annotation.body['duration']).to eq 1000
-          expect(annotation.body['label']).to eq('none' => ['Reel 1'])
-          expect(annotation.body['format']).to eq 'video/mp4'
-          expect(annotation.body['service']).to include auth_service
-        end
-
-        context 'multiple auth services' do
+      describe 'authorization services' do
+        context 'with auth service' do
           let(:auth_service) do
-            [
-              {
-                context: "http://iiif.io/api/auth/1/context.json",
-                id: "http://example.org/iiif/loginservice",
-                confirmLabel: "Login",
-                description: "...",
-                failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
-                failureHeader: "Authentication Failed",
-                header: "This material requires authorization",
-                label: "This material requires authorization",
-                profile: "http://iiif.io/api/auth/1/login",
-                service: [
-                  {
-                    context: "http://iiif.io/api/auth/1/context.json",
-                    id: "http://example.org/iiif/token",
-                    profile: "http://iiif.io/api/auth/1/token"
-                  },
-                  {
-                    context: "http://iiif.io/api/auth/1/context.json",
-                    id: "http://example.org/iiif/logout",
-                    label: "Log out",
-                    profile: "http://iiif.io/api/auth/1/logout"
-                  }
-                ]
-              },
-              {
-                id: "http://example.org/iiif/probe",
-                type: "AuthProbeService2",
-                service: [
-                  {
-                    id: "http://example.org/auth",
-                    type: "AuthAccessService2",
-                    profile: "active",
-                    service: [
-                      {
-                        id: "http://example.org/auth_token",
-                        type: "AuthAccessTokenService2"
-                      },
-                      {
-                        id: "http://example.org/logout",
-                        type: "AuthLogoutService2",
-                        label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+            {
+              context: "http://iiif.io/api/auth/1/context.json",
+              id: "http://example.org/iiif/loginservice",
+              confirmLabel: "Login",
+              description: "...",
+              failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
+              failureHeader: "Authentication Failed",
+              header: "This material requires authorization",
+              label: "This material requires authorization",
+              profile: "http://iiif.io/api/auth/1/login",
+              service: [
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/token",
+                  profile: "http://iiif.io/api/auth/1/token"
+                },
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/logout",
+                  label: "Log out",
+                  profile: "http://iiif.io/api/auth/1/logout"
+                }
+              ]
+            }
+          end
+          let(:display_content) do
+            IIIFManifest::V3::DisplayContent.new(url, width: 640,
+                                                      height: 480,
+                                                      duration: 1000,
+                                                      type: 'Video',
+                                                      format: 'video/mp4',
+                                                      label: 'Reel 1',
+                                                      auth_service: auth_service)
           end
 
-          it '' do
+          it 'sets a body on the annotation' do
             subject
-            expect(annotation.body['service']).to eq auth_service
+            expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+            expect(annotation.body['id']).to eq url
+            expect(annotation.body['type']).to eq 'Video'
+            expect(annotation.body['width']).to eq 640
+            expect(annotation.body['height']).to eq 480
+            expect(annotation.body['duration']).to eq 1000
+            expect(annotation.body['label']).to eq('none' => ['Reel 1'])
+            expect(annotation.body['format']).to eq 'video/mp4'
+            expect(annotation.body['service']).to include auth_service
+          end
+        end
+
+        context 'with auth2 service' do
+          let(:auth2_service) do
+            {
+              id: "http://example.org/iiif/probe",
+              type: "AuthProbeService2",
+              service: [
+                {
+                  id: "http://example.org/auth",
+                  type: "AuthAccessService2",
+                  profile: "active",
+                  service: [
+                    {
+                      id: "http://example.org/auth_token",
+                      type: "AuthAccessTokenService2"
+                    },
+                    {
+                      id: "http://example.org/logout",
+                      type: "AuthLogoutService2",
+                      label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+          let(:display_content) do
+            IIIFManifest::V3::DisplayContent.new(url, width: 640,
+                                                      height: 480,
+                                                      duration: 1000,
+                                                      type: 'Video',
+                                                      format: 'video/mp4',
+                                                      label: 'Reel 1',
+                                                      auth2_service: auth2_service)
+          end
+
+          it 'sets a body on the annotation' do
+            subject
+            expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+            expect(annotation.body['id']).to eq url
+            expect(annotation.body['type']).to eq 'Video'
+            expect(annotation.body['width']).to eq 640
+            expect(annotation.body['height']).to eq 480
+            expect(annotation.body['duration']).to eq 1000
+            expect(annotation.body['label']).to eq('none' => ['Reel 1'])
+            expect(annotation.body['format']).to eq 'video/mp4'
+            expect(annotation.body['service']).to include auth2_service
+          end
+        end
+
+        context 'with auth service and auth 2 service' do
+          let(:auth_service) do
+            {
+              context: "http://iiif.io/api/auth/1/context.json",
+              id: "http://example.org/iiif/loginservice",
+              confirmLabel: "Login",
+              description: "...",
+              failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
+              failureHeader: "Authentication Failed",
+              header: "This material requires authorization",
+              label: "This material requires authorization",
+              profile: "http://iiif.io/api/auth/1/login",
+              service: [
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/token",
+                  profile: "http://iiif.io/api/auth/1/token"
+                },
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/logout",
+                  label: "Log out",
+                  profile: "http://iiif.io/api/auth/1/logout"
+                }
+              ]
+            }
+          end
+          let(:auth2_service) do
+            {
+              id: "http://example.org/iiif/probe",
+              type: "AuthProbeService2",
+              service: [
+                {
+                  id: "http://example.org/auth",
+                  type: "AuthAccessService2",
+                  profile: "active",
+                  service: [
+                    {
+                      id: "http://example.org/auth_token",
+                      type: "AuthAccessTokenService2"
+                    },
+                    {
+                      id: "http://example.org/logout",
+                      type: "AuthLogoutService2",
+                      label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+          let(:display_content) do
+            IIIFManifest::V3::DisplayContent.new(url, width: 640,
+                                                      height: 480,
+                                                      duration: 1000,
+                                                      type: 'Video',
+                                                      format: 'video/mp4',
+                                                      label: 'Reel 1',
+                                                      auth_service: auth_service,
+                                                      auth2_service: auth2_service)
+          end
+
+          it 'creates an array of auth services' do
+            subject
+            expect(annotation.body['service']).to be_an(Array)
             expect(annotation.body['service'].all?(Hash)).to be_truthy
             expect(annotation.body['service'].count).to eq 2
+            expect(annotation.body['service']).to include auth_service
+            expect(annotation.body['service']).to include auth2_service
           end
         end
       end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -180,52 +180,54 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
 
         context 'multiple auth services' do
           let(:auth_service) do
-            [{
-              context: "http://iiif.io/api/auth/1/context.json",
-              id: "http://example.org/iiif/loginservice",
-              confirmLabel: "Login",
-              description: "...",
-              failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
-              failureHeader: "Authentication Failed",
-              header: "This material requires authorization",
-              label: "This material requires authorization",
-              profile: "http://iiif.io/api/auth/1/login",
-              service: [
-                {
-                  context: "http://iiif.io/api/auth/1/context.json",
-                  id: "http://example.org/iiif/token",
-                  profile: "http://iiif.io/api/auth/1/token"
-                },
-                {
-                  context: "http://iiif.io/api/auth/1/context.json",
-                  id: "http://example.org/iiif/logout",
-                  label: "Log out",
-                  profile: "http://iiif.io/api/auth/1/logout"
-                }
-              ]
-            },
-            {
-              id: "http://example.org/iiif/probe",
-              type: "AuthProbeService2",
-              service: [
-                {
-                  id: "http://example.org/auth",
-                  type: "AuthAccessService2",
-                  profile: "active",
-                  service: [
-                    {
-                      id: "http://example.org/auth_token",
-                      type: "AuthAccessTokenService2",
-                    },
-                    {
-                      id: "http://example.org/logout",
-                      type: "AuthLogoutService2",
-                      label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
-                    }
-                  ]
-                }
-              ]
-            }]
+            [
+              {
+                context: "http://iiif.io/api/auth/1/context.json",
+                id: "http://example.org/iiif/loginservice",
+                confirmLabel: "Login",
+                description: "...",
+                failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
+                failureHeader: "Authentication Failed",
+                header: "This material requires authorization",
+                label: "This material requires authorization",
+                profile: "http://iiif.io/api/auth/1/login",
+                service: [
+                  {
+                    context: "http://iiif.io/api/auth/1/context.json",
+                    id: "http://example.org/iiif/token",
+                    profile: "http://iiif.io/api/auth/1/token"
+                  },
+                  {
+                    context: "http://iiif.io/api/auth/1/context.json",
+                    id: "http://example.org/iiif/logout",
+                    label: "Log out",
+                    profile: "http://iiif.io/api/auth/1/logout"
+                  }
+                ]
+              },
+              {
+                id: "http://example.org/iiif/probe",
+                type: "AuthProbeService2",
+                service: [
+                  {
+                    id: "http://example.org/auth",
+                    type: "AuthAccessService2",
+                    profile: "active",
+                    service: [
+                      {
+                        id: "http://example.org/auth_token",
+                        type: "AuthAccessTokenService2"
+                      },
+                      {
+                        id: "http://example.org/logout",
+                        type: "AuthLogoutService2",
+                        label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           end
 
           it '' do

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -177,6 +177,64 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['format']).to eq 'video/mp4'
           expect(annotation.body['service']).to include auth_service
         end
+
+        context 'multiple auth services' do
+          let(:auth_service) do
+            [{
+              context: "http://iiif.io/api/auth/1/context.json",
+              id: "http://example.org/iiif/loginservice",
+              confirmLabel: "Login",
+              description: "...",
+              failureDescription: "<a href=\"http://example.org/policy\">Access Policy</a>",
+              failureHeader: "Authentication Failed",
+              header: "This material requires authorization",
+              label: "This material requires authorization",
+              profile: "http://iiif.io/api/auth/1/login",
+              service: [
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/token",
+                  profile: "http://iiif.io/api/auth/1/token"
+                },
+                {
+                  context: "http://iiif.io/api/auth/1/context.json",
+                  id: "http://example.org/iiif/logout",
+                  label: "Log out",
+                  profile: "http://iiif.io/api/auth/1/logout"
+                }
+              ]
+            },
+            {
+              id: "http://example.org/iiif/probe",
+              type: "AuthProbeService2",
+              service: [
+                {
+                  id: "http://example.org/auth",
+                  type: "AuthAccessService2",
+                  profile: "active",
+                  service: [
+                    {
+                      id: "http://example.org/auth_token",
+                      type: "AuthAccessTokenService2",
+                    },
+                    {
+                      id: "http://example.org/logout",
+                      type: "AuthLogoutService2",
+                      label: { "en": [I18n.t('iiif.auth.logoutLabel')] }
+                    }
+                  ]
+                }
+              ]
+            }]
+          end
+
+          it '' do
+            subject
+            expect(annotation.body['service']).to eq auth_service
+            expect(annotation.body['service'].all?(Hash)).to be_truthy
+            expect(annotation.body['service'].count).to eq 2
+          end
+        end
       end
 
       describe 'annotation_content' do

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -209,6 +209,40 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
           expect(result['items'].first['items'].first['items'].first['body']['duration']).to eq 360_000
           expect(result['items'].first['items'].first['items'].first['body']['format']).to eq 'audio/mp4'
         end
+
+        it 'returns default @context' do
+          expect(result['@context']).to eq ['http://www.w3.org/ns/anno.jsonld', 'http://iiif.io/api/presentation/3/context.json']
+        end
+
+        context 'auth2_service present' do
+          class AudioFileAuthPresenter
+            attr_reader :id, :label
+            def initialize(id: 'test-22', label: 'Disc 1')
+              @id = id
+              @label = label
+            end
+
+            def to_s
+              label
+            end
+
+            def display_content
+              IIIFManifest::V3::DisplayContent.new(id,
+                                                   type: 'Sound',
+                                                   duration: 360_000,
+                                                   format: 'audio/mp4',
+                                                   auth2_service: { id: 'test' })
+            end
+          end
+
+          let(:file_presenter) { AudioFileAuthPresenter.new }
+
+          it 'sets the manifest context' do
+            allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
+
+            expect(result['@context'][1]).to eq 'http://iiif.io/api/auth/2/context.json'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Avalon is working on updating their IIIF auth service to 2.0 which requires adding a value to the top level context. This commit adds the ability to override the default context in V3 manifests by defining a `context` method on the manifest presenter and passing an array of values.

Additionally, this commit changes the behavior of the `auth_service` so that implementers can pass in an array of hashes. This is to facilitate any implementations that may want to have Auth 1 and Auth 2 services defined, or adding additional auth services if and when the IIIF community defines additional versions.