### PR TITLE
Add canvas metadata support for V2 manifests

### DIFF
--- a/lib/iiif_manifest/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder.rb
@@ -35,6 +35,21 @@ module IIIFManifest
       def apply_record_properties
         canvas['@id'] = path
         canvas.label = record.to_s
+        canvas['metadata'] = record.item_metadata if valid_item_metadata?
+      end
+
+      # Validate item_metadata is an array of hashes with label and value
+      # as required keys for each entry
+      #
+      # @return [Boolean]
+      def valid_item_metadata?
+        return false unless record.respond_to?(:item_metadata)
+        metadata = record.item_metadata
+        metadata.is_a?(Array) && metadata.all? do |metadata_field|
+          metadata_field.is_a?(Hash) &&
+            metadata_field['label'].present? &&
+            metadata_field['value'].present?
+        end
       end
 
       def attach_image

--- a/spec/lib/iiif_manifest/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_builder/canvas_builder_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::ManifestBuilder::CanvasBuilder do
+  let(:builder) do
+    described_class.new(
+      record,
+      parent,
+      iiif_canvas_factory: IIIFManifest::ManifestBuilder::IIIFManifest::Canvas,
+      image_builder: IIIFManifest::ManifestServiceLocator.image_builder
+    )
+  end
+  let(:record) { MyWork.new }
+  let(:parent) { MyParent.new }
+
+  before do
+    class MyWork
+      def id
+        'test-22'
+      end
+
+      def to_s
+        'Test Work'
+      end
+    end
+
+    class MyParent
+      def manifest_url
+        'http://test.host/books/book-77/manifest'
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :MyWork)
+    Object.send(:remove_const, :MyParent)
+  end
+
+  describe '#canvas' do
+    it 'sets the id and label' do
+      values = builder.canvas.inner_hash
+
+      expect(values['@id']).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
+      expect(values['label']).to eq 'Test Work'
+    end
+
+    context 'when the record has no item_metadata method' do
+      it 'does not have a metadata element' do
+        expect(builder.canvas.inner_hash).not_to include 'metadata'
+      end
+    end
+
+    context 'when the record has item_metadata' do
+      before do
+        class MyWork
+          def item_metadata
+            [{ 'label' => 'Title', 'value' => 'Title of the Item' }]
+          end
+        end
+      end
+
+      it 'has metadata' do
+        values = builder.canvas.inner_hash
+
+        expect(values['metadata']).to eq [{ 'label' => 'Title', 'value' => 'Title of the Item' }]
+      end
+    end
+
+    context 'when the item_metadata is missing required keys' do
+      before do
+        class MyWork
+          def item_metadata
+            [{ 'label' => 'Title' }]
+          end
+        end
+      end
+
+      it 'does not have a metadata element' do
+        expect(builder.canvas.inner_hash).not_to include 'metadata'
+      end
+    end
+
+    context 'when the item_metadata is not an array' do
+      before do
+        class MyWork
+          def item_metadata
+            'Title of the Item'
+          end
+        end
+      end
+
+      it 'does not have a metadata element' do
+        expect(builder.canvas.inner_hash).not_to include 'metadata'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior, displaying metadata on the canvas level for V2 manifests was not supported.  This commit mimics the way V3 manifests add metadata for items.  When a file set presenter responds to #item_metadata with an array of label/value hashes, the canvas builder writes it to the canvas's metadata key.  Records that don't implement #item_metadata are unaffected.