### PR TITLE
Add IIIFManifest::ManifestRange object

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Additionally it **_may_** implement `#service` to contain an array of hashes for
 
 Additionally it **_may_** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`).
 
-Finally, it **_may_** implement `ranges`, which returns an array of objects which represent a table of contents or similar structure, each of which responds to `label`, `ranges`, and `file_set_presenters`.
+Finally, it **_may_** implement `ranges`, which returns an array of objects which represent a table of contents or similar structure, each of which responds to `label`, `ranges`, and `file_set_presenters`. `IIIFManifest::ManifestRange` is provided for this purpose; any object with those three methods will also work.
 
 For example:
 
@@ -94,25 +94,16 @@ For example:
 
     def ranges
       [
-        ManifestRange.new(
+        IIIFManifest::ManifestRange.new(
           label: "Table of Contents",
           ranges: [
-            ManifestRange.new(
+            IIIFManifest::ManifestRange.new(
               label: "Chapter 1",
               file_set_presenters: @pages
             )
           ]
         )
       ]
-    end
-  end
-
-  class ManifestRange
-    attr_reader :label, :ranges, :file_set_presenters
-    def initialize(label:, ranges: [], file_set_presenters: [])
-      @label = label
-      @ranges = ranges
-      @file_set_presenters = file_set_presenters
     end
   end
 ```

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -8,6 +8,7 @@ module IIIFManifest
   autoload :Configuration
   autoload :ManifestBuilder
   autoload :ManifestFactory
+  autoload :ManifestRange
   autoload :ManifestServiceLocator
   autoload :DisplayImage
   autoload :IIIFCollection

--- a/lib/iiif_manifest/manifest_range.rb
+++ b/lib/iiif_manifest/manifest_range.rb
@@ -1,0 +1,11 @@
+module IIIFManifest
+  class ManifestRange
+    attr_reader :label, :ranges, :file_set_presenters
+
+    def initialize(label:, ranges: [], file_set_presenters: [])
+      @label = label
+      @ranges = ranges
+      @file_set_presenters = file_set_presenters
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/manifest_factory_spec.rb
@@ -32,19 +32,13 @@ RSpec.describe IIIFManifest::ManifestFactory do
       def ranges
         @ranges ||=
           [
-            ManifestRange.new(label: 'Table of Contents', ranges: [
-                                ManifestRange.new(label: 'Chapter 1', file_set_presenters: [])
-                              ])
+            IIIFManifest::ManifestRange.new(
+              label: 'Table of Contents',
+              ranges: [
+                IIIFManifest::ManifestRange.new(label: 'Chapter 1', file_set_presenters: [])
+              ]
+            )
           ]
-      end
-    end
-
-    class ManifestRange
-      attr_reader :label, :ranges, :file_set_presenters
-      def initialize(label:, ranges: [], file_set_presenters: [])
-        @label = label
-        @ranges = ranges
-        @file_set_presenters = file_set_presenters
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -36,23 +36,17 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       def ranges
         @ranges ||=
           [
-            ManifestRange.new(label: 'Table of Contents', ranges: [
-                                ManifestRange.new(label: 'Chapter 1', file_set_presenters: [])
-                              ])
+            IIIFManifest::ManifestRange.new(
+              label: 'Table of Contents',
+              ranges: [
+                IIIFManifest::ManifestRange.new(label: 'Chapter 1', file_set_presenters: [])
+              ]
+            )
           ]
       end
     end
 
     class AudioBook < Book
-    end
-
-    class ManifestRange
-      attr_reader :label, :ranges, :file_set_presenters
-      def initialize(label:, ranges: [], file_set_presenters: [])
-        @label = label
-        @ranges = ranges
-        @file_set_presenters = file_set_presenters
-      end
     end
 
     class DisplayImagePresenter
@@ -483,8 +477,12 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       let(:child_work_presenter) { presenter_class.new('test-99') }
       let(:file_presenter) { DisplayImagePresenter.new(id: 'test-22') }
       let(:file_presenter2) { DisplayImagePresenter.new(id: 'test-33', label: 'Page 2') }
-      let(:chapter_1_range) { ManifestRange.new(label: 'Chapter 1', file_set_presenters: [file_presenter]) }
-      let(:child_work_range) { ManifestRange.new(label: 'Child Work', file_set_presenters: [file_presenter2]) }
+      let(:chapter_1_range) do
+        IIIFManifest::ManifestRange.new(label: 'Chapter 1', file_set_presenters: [file_presenter])
+      end
+      let(:child_work_range) do
+        IIIFManifest::ManifestRange.new(label: 'Child Work', file_set_presenters: [file_presenter2])
+      end
 
       before do
         allow(book_presenter).to receive(:work_presenters).and_return([child_work_presenter])


### PR DESCRIPTION
Previously, applications had to roll their own ManifestRange object that would populate the work's #ranges.  This commit introduces IIIFManifest::ManifestRange as a first class citizen of the gem.